### PR TITLE
Add vectorized PyTorch implementation

### DIFF
--- a/make_torchbench.sh
+++ b/make_torchbench.sh
@@ -2,3 +2,4 @@
 
 source ./venv3/bin/activate
 python3 torch_fizz.py
+python3 torch_fizz_vec.py

--- a/torch_fizz_vec.py
+++ b/torch_fizz_vec.py
@@ -1,0 +1,89 @@
+import time
+
+import torch
+
+class TorchFizzBuzzVec(torch.nn.Module):
+    def __init__(self):
+        super(TorchFizzBuzzVec, self).__init__()
+
+    def forward(self, n: torch.Tensor):
+        x = torch.arange(n)
+        ones = torch.ones(n)
+        zeros = torch.zeros(n)
+
+        fizzbuzz = torch.sum(torch.where(x % 6 == 0, ones, zeros)).unsqueeze(0)
+        buzz = torch.sum(torch.where((x % 3 == 0) & (x % 6 != 0), ones, zeros)).unsqueeze(0)
+        fizz = torch.sum(torch.where((x % 2 == 0) & (x % 6 != 0), ones, zeros)).unsqueeze(0)
+
+        return torch.stack([fizz, buzz, fizzbuzz])
+
+class PyFizzBuzz:
+    def model(self, n):
+        fizz = 0
+        buzz = 0
+        fizzbuzz = 0
+        for i in range(n):
+            if i % 6 == 0:
+                fizzbuzz += 1
+            elif i % 3 == 0:
+                buzz += 1
+            elif i % 2 == 0:
+                fizz += 1
+        return [fizz, buzz, fizzbuzz]
+
+
+torch.no_grad()
+COUNT = 100000
+n = torch.tensor(COUNT, dtype=torch.int32)
+
+print("Saving PyTorch vectorized model.")
+mod = TorchFizzBuzzVec()
+# Convert to code
+jit_script = torch.jit.script(mod)
+print(jit_script)
+print(jit_script.code)
+torch.jit.save(jit_script, '/tmp/fizzbuzz.pyt')
+
+mod = TorchFizzBuzzVec()
+mod.eval()
+start_ns = time.perf_counter_ns()
+result = mod.forward(n)
+end_ns = time.perf_counter_ns()
+print("Result: ", result)
+print("Time (PyTorch vectorized) (ms): ", (end_ns - start_ns)/1e6)
+
+mod = TorchFizzBuzzVec()
+mod.eval()
+with torch.jit.optimized_execution(True):
+    start_ns = time.perf_counter_ns()
+    result = mod.forward(n)
+    end_ns = time.perf_counter_ns()
+
+print("Result: ", result)
+print("Time (PyTorch vectorized, optimized=True) (ms): ", (end_ns - start_ns)/1e6)
+
+mod = TorchFizzBuzzVec()
+mod.eval()
+with torch.jit.optimized_execution(False):
+    start_ns = time.perf_counter_ns()
+    result = mod.forward(n)
+    end_ns = time.perf_counter_ns()
+print("Result: ", result)
+print("Time (PyTorch vectorized, optimized=False) (ms): ", (end_ns - start_ns)/1e6)
+
+print("Loading PyTorch model.")
+loaded_module = torch.jit.load('/tmp/fizzbuzz.pyt')
+loaded_module.eval()
+start_ns = time.perf_counter_ns()
+result = loaded_module.forward(n)
+end_ns = time.perf_counter_ns()
+print("Result: ", result)
+print("Time (PyTorch vectorized from Loaded) (ms): ", (end_ns - start_ns)/1e6)
+
+pymod = PyFizzBuzz()
+perf_counter_ns_start = time.perf_counter_ns()
+result = pymod.model(COUNT)
+perf_counter_ns_end = time.perf_counter_ns()
+time_taken_ns = perf_counter_ns_end - perf_counter_ns_start
+print('Result: ', result)
+print('Time taken (Python3) (ms): ', time_taken_ns / 1e6)


### PR DESCRIPTION
Alternative vectorized implementation that achieves improved performance by avoiding the procedural control flow at each iteration. Below are the benchmarks on my machine.

Hardware Specifications
----------------------
  Model Name:	MacBook Pro
  Model Identifier:	MacBookPro14,3
  Processor Name:	Intel Core i7
  Processor Speed:	2.9 GHz
  Number of Processors:	1
  Total Number of Cores:	4
  L2 Cache (per Core):	256 KB
  L3 Cache:	8 MB
  Hyper-Threading Technology:	Enabled
  Memory:	16 GB
  Boot ROM Version:	198.71.1.0.0

Non-Vectorized Results
----------------------
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch) (ms):  3640.467067
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch optimized=True) (ms):  3319.941812
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch optimized=False) (ms):  3589.502357
Loading PyTorch model.
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch from Loaded) (ms):  2652.601182
Result:  [33333, 16667, 16667]
Time taken (Python3) (ms):  15.974578

Vectorized Results
----------------------
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch) (ms):  8.003058
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch optimized=True) (ms):  5.719696
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch optimized=False) (ms):  5.108484
Loading PyTorch model.
Result:  tensor([[33333.],
        [16667.],
        [16667.]])
Time (PyTorch from Loaded) (ms):  8.081866
Result:  [33333, 16667, 16667]
Time taken (Python3) (ms):  14.489777